### PR TITLE
ci: add certificate auto-update workflow

### DIFF
--- a/.github/workflows/cert.yml
+++ b/.github/workflows/cert.yml
@@ -1,0 +1,50 @@
+name: Update Certificate
+
+on: 
+  workflow_dispatch:
+  schedule:
+    # Run every Wednesday at midnight
+    - cron: 0 0 * * WED
+
+jobs:
+  update-cert:
+    runs-on: ubuntu-latest
+    env: 
+      ocaml-compiler: "5.1"
+    steps:
+    - name: Checkout tree
+      uses: actions/checkout@v4
+
+    - name: Download certificate
+      shell: bash
+      run: ./download_pem.sh
+
+    - name: Check for changes
+      id: check_changes
+      continue-on-error: true
+      run: |
+        if git diff --quiet main~1 cacert.pem; then
+          echo "No changes to cacert.pem. Skipping build."
+          exit 1
+        fi
+
+    - name: Set-up OCaml
+      uses: ocaml/setup-ocaml@v2
+      if: steps.check_changes.outcome == 'success'
+      with:
+        ocaml-compiler: ${{ env.ocaml-compiler }}
+    - run: |
+        opam install castore x509 ca-certs cstruct mdx ocamlformat
+        opam exec -- dune build
+        ./_build/default/regen.exe
+        opam exec -- dune fmt || true
+
+    - name: Bump version and create release
+      if: steps.check_changes.outcome == 'success'
+      run: |
+        current_version=$(git describe --tags --abbrev=0)
+        IFS='.' read -r major minor patch <<< "$current_version"
+        new_version="$major.$minor.$((patch + 1))"
+        
+        git tag "$new_version"
+        git push origin "$new_version"

--- a/.github/workflows/cert.yml
+++ b/.github/workflows/cert.yml
@@ -48,3 +48,6 @@ jobs:
         
         git tag "$new_version"
         git push origin "$new_version"
+        gh release create "$new_version" --generate-notes
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/regen.ml
+++ b/regen.ml
@@ -85,7 +85,7 @@ let generate_cas pem =
     String.concat ";\n" (List.map (fun ca -> Format.asprintf "{|%s|}" ca) cas)
   in
   let file = Format.sprintf "let certificates = [\n%s\n] " cas in
-  let oc = open_out "cas.ml" in
+  let oc = open_out "certificates.ml" in
   Out_channel.output_string oc file;
   Printf.printf "🔒 Generated certificates.ml\n";
   close_out oc


### PR DESCRIPTION
### Description

Add workflow file to check and auto update certificates. If a new certificate is found, we regenerate `certificates.ml` and `pem.ml` files and create a new patch release.