### PR TITLE
Make x509 a regular dependency

### DIFF
--- a/castore.opam
+++ b/castore.opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/leostera/castore/issues"
 depends: [
   "ocaml" {>= "5.1"}
   "mdx" {with-test & >= "2.3.1"}
-  "x509" {with-doc & >= "0.16.5"}
+  "x509" {>= "0.16.5"}
   "dune" {>= "3.11"}
   "odoc" {with-doc}
 ]

--- a/dune-project
+++ b/dune-project
@@ -19,6 +19,6 @@
  (depends 
    (ocaml (>="5.1")) 
    (mdx (and :with-test (>= "2.3.1")))
-   (x509 (and :with-doc (>= "0.16.5")))
+   (x509 (>= "0.16.5"))
    dune)
  (tags (https tls cert crt pem ca "ca store")))


### PR DESCRIPTION
`x509` is required as a regular dependency, not doc-only, as

```sh
$ opam switch install . --deps-only --with-test
$ dune runtest
```

yields an error message like this:

```
File "dune", line 17, characters 28-32:
17 |  (libraries castore cstruct x509))
                                 ^^^^
Error: Library "x509" not found.
-> required by _build/default/decode_test.exe
-> required by alias runtest in dune:15
File "dune", line 2, characters 12-16:     
2 |  (libraries x509 castore))
                ^^^^
Error: Library "x509" not found.
-> required by _build/default/mdx_gen.bc
-> required by _build/default/.mdx/CHANGES.md.corrected
-> required by alias runtest in dune:1
```

Installing `x509` manually using `opam install x509` fixes this.